### PR TITLE
Upgrade go version

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -6,7 +6,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/code-formatter@main
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ministryofjustice/github-actions/code-formatter@7c689fe2de15e1692f5cceceb132919ab854081c # v14
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -18,7 +18,7 @@ jobs:
       # Install Go on the VM running the action.
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.19.x"
+          go-version: "1.21.x"
 
       - name: Perform staticcheck on codebase
         uses: dominikh/staticcheck-action@ba605356b4b29a60e87ab9404b712f3461e566dc # v1.3.0

--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -13,15 +13,15 @@ jobs:
     steps:
       # Checkout your project with git
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Install Go on the VM running the action.
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.19.x"
 
       - name: Perform staticcheck on codebase
-        uses: dominikh/staticcheck-action@v1.3.0
+        uses: dominikh/staticcheck-action@ba605356b4b29a60e87ab9404b712f3461e566dc # v1.3.0
         with:
           version: "2022.1.3"
           install-go: false
@@ -35,7 +35,7 @@ jobs:
           gofumpt -l -d ./
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Perform staticcheck on codebase
         uses: dominikh/staticcheck-action@ba605356b4b29a60e87ab9404b712f3461e566dc # v1.3.0
         with:
-          version: "2022.1.3"
+          version: "2023.1.6"
           install-go: false
 
       - name: Install gofumpt


### PR DESCRIPTION
## Purpose

- Bump go version from 1.19.x to 1.21.x in the workflow file

Related to https://github.com/ministryofjustice/cloud-platform-directory-hash/actions/runs/14219764988/job/39844679812?pr=21