### PR TITLE
Updating vet lint deps to remove unsupported 3rd party actions

### DIFF
--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -18,7 +18,7 @@ jobs:
       # Install Go on the VM running the action.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.21.x"
+          go-version: "1.24.x"
 
       - name: Install gofumpt
         run: |

--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -13,18 +13,12 @@ jobs:
     steps:
       # Checkout your project with git
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       # Install Go on the VM running the action.
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.21.x"
-
-      - name: Perform staticcheck on codebase
-        uses: dominikh/staticcheck-action@ba605356b4b29a60e87ab9404b712f3461e566dc # v1.3.0
-        with:
-          version: "2023.1.6"
-          install-go: false
+          go-version: "1.26.x"
 
       - name: Install gofumpt
         run: |
@@ -35,7 +29,7 @@ jobs:
           gofumpt -l -d ./
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -13,12 +13,12 @@ jobs:
     steps:
       # Checkout your project with git
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Install Go on the VM running the action.
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24.x"
+          go-version: "1.21.x"
 
       - name: Install gofumpt
         run: |
@@ -29,7 +29,7 @@ jobs:
           gofumpt -l -d ./
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -18,7 +18,7 @@ jobs:
       # Install Go on the VM running the action.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.x"
+          go-version: "1.21.x"
 
       - name: Install gofumpt
         run: |

--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -13,12 +13,12 @@ jobs:
     steps:
       # Checkout your project with git
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       # Install Go on the VM running the action.
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.21.x"
+          go-version: "1.26.x"
 
       - name: Install gofumpt
         run: |
@@ -29,7 +29,7 @@ jobs:
           gofumpt -l -d ./
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/cmd/directory-hash/main.go
+++ b/cmd/directory-hash/main.go
@@ -9,8 +9,10 @@ import (
 	create "golang.org/x/mod/sumdb/dirhash"
 )
 
-const fileName string = ".checksum"
-const base string = "namespaces/live.cloud-platform.service.justice.gov.uk"
+const (
+	fileName string = ".checksum"
+	base     string = "namespaces/live.cloud-platform.service.justice.gov.uk"
+)
 
 func main() {
 	// DefaultHash is the default hash function used to hash a directory.

--- a/pkg/hashdir/hashdir.go
+++ b/pkg/hashdir/hashdir.go
@@ -28,7 +28,7 @@ func ReadChecksum(f string) (userHash, namespace string) {
 		fmt.Println(err)
 	}
 
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)

--- a/pkg/hashdir/hashdir.go
+++ b/pkg/hashdir/hashdir.go
@@ -1,6 +1,6 @@
 // Package hashdir will compare two directory hashes and
 // perform an action on the outcome. It is intended to be used
-// in a GitHub action
+// in a GitHub action.
 package hashdir
 
 import (

--- a/pkg/hashdir/hashdir.go
+++ b/pkg/hashdir/hashdir.go
@@ -1,6 +1,6 @@
 // Package hashdir will compare two directory hashes and
 // perform an action on the outcome. It is intended to be used
-// in a GitHub action.
+// in a GitHub action
 package hashdir
 
 import (


### PR DESCRIPTION
Done as a part of [#8128](https://github.com/ministryofjustice/cloud-platform/issues/8128)

For Go vet lint deps action:
- Removing unsupported 3rd party actions
- Bumping versions of actions 